### PR TITLE
Adding tests to new Collection, refactoring Collection and extending

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -50,7 +50,7 @@ class ApiClient
 	/**
 	 * Retrieves app-data from `api.ethicaljobs.com.au/` base route
 	 * 
-	 * @return Illuminate\Support\Collection
+	 * @return EthicalJobs\SDK\Collection
 	 */
    	public function appData()
    	{

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace EthicalJobs\SDK;
+
+/**
+ * Response selector
+ *
+ * @author Andrew McLagan <andrew@ethicaljobs.com.au>
+ */
+
+class Collection extends \Illuminate\Support\Collection
+{
+	/**
+	 * Api response selector
+	 *
+	 * @return $this
+	 */
+	public function select(): ResponseSelector
+	{
+		return new ResponseSelector($this);
+	}	
+}

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -5,7 +5,6 @@ namespace EthicalJobs\SDK;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Collection;
 use GuzzleHttp\Exception\ClientException;
 use EthicalJobs\SDK\Authentication\Authenticator;
 use EthicalJobs\SDK\Router;
@@ -67,7 +66,7 @@ class HttpClient
 	 * @param  string $route   
 	 * @param  array  $body    
 	 * @param  array  $headers 
-	 * @return Illuminate\Support\Collection     
+	 * @return EthicalJobs\SDK\Collection     
 	 */
 	public function get(string $route, $body = [], $headers = [])
 	{
@@ -80,7 +79,7 @@ class HttpClient
 	 * @param  string $route   
 	 * @param  array  $body    
 	 * @param  array  $headers 
-	 * @return Illuminate\Support\Collection      
+	 * @return EthicalJobs\SDK\Collection      
 	 */
 	public function post(string $route, $body = [], $headers = [])
 	{
@@ -93,7 +92,7 @@ class HttpClient
 	 * @param  string $route   
 	 * @param  array  $body    
 	 * @param  array  $headers 
-	 * @return Illuminate\Support\Collection     
+	 * @return EthicalJobs\SDK\Collection     
 	 */
 	public function put(string $route, $body = [], $headers = [])
 	{
@@ -106,7 +105,7 @@ class HttpClient
 	 * @param  string $route   
 	 * @param  array  $body    
 	 * @param  array  $headers 
-	 * @return Illuminate\Support\Collection            
+	 * @return EthicalJobs\SDK\Collection            
 	 */
 	public function patch(string $route, $body = [], $headers = [])
 	{
@@ -119,7 +118,7 @@ class HttpClient
 	 * @param  string $route   
 	 * @param  array  $body    
 	 * @param  array  $headers 
-	 * @return Illuminate\Support\Collection  
+	 * @return EthicalJobs\SDK\Collection  
 	 */
 	public function delete(string $route, $body = [], $headers = [])
 	{
@@ -133,7 +132,7 @@ class HttpClient
 	 * @param  string $route   
 	 * @param  array  $body    
 	 * @param  array  $headers 
-	 * @return Illuminate\Support\Collection         
+	 * @return EthicalJobs\SDK\Collection         
 	 */
 	public function request(string $verb, string $route, $body = [], $headers = []): Collection
 	{
@@ -221,7 +220,7 @@ class HttpClient
 	 * Dispatches a request and returns a response instance
 	 *
 	 * @param GuzzleHttp\Psr7\Request $request
-	 * @return Illuminate\Support\Collection
+	 * @return EthicalJobs\SDK\Collection
 	 */
 	protected function dispatchRequest(Request $request): Collection
 	{
@@ -247,7 +246,7 @@ class HttpClient
 	 * Prases a response and returns a collection or item
 	 *
 	 * @param GuzzleHttp\Psr7\Response $response
-	 * @return Illuminate\Support\Collection
+	 * @return EthicalJobs\SDK\Collection
 	 */
 	protected function parseResponse(Response $response)
 	{

--- a/src/Repositories/ResourceRepository.php
+++ b/src/Repositories/ResourceRepository.php
@@ -2,7 +2,7 @@
 
 namespace EthicalJobs\SDK\Repositories;
 
-use Illuminate\Support\Collection;
+use EthicalJobs\SDK\Collection;
 use Illuminate\Support\Facades\App;
 use EthicalJobs\SDK\HttpClient;
 use EthicalJobs\SDK\Resources;
@@ -18,7 +18,7 @@ class ResourceRepository
     /**
      * Collection of api resources
      *
-     * @var Illuminate\Support\Collection
+     * @var EthicalJobs\SDK\Collection
      */
     protected $collection;
 
@@ -55,7 +55,7 @@ class ResourceRepository
     /**
      * Return collection of resource instances
      *
-     * @return Illuminate\Support\Collection
+     * @return EthicalJobs\SDK\Collection
      */
     public static function all()
     {

--- a/src/Resources/JobsResource.php
+++ b/src/Resources/JobsResource.php
@@ -3,7 +3,7 @@
 namespace EthicalJobs\SDK\Resources;
 
 use EthicalJobs\SDK\Enumerables;
-use Illuminate\Support\Collection;
+use EthicalJobs\SDK\Collection;
 
 /**
  * Jobs api resource
@@ -25,7 +25,7 @@ class JobsResource extends ApiResource
    	 * Returns approved jobs
    	 *
    	 * @param Array $params
-   	 * @return Illuminate\Support\Collection
+   	 * @return EthicalJobs\SDK\Collection
 	 */		
 	public function approved($params = [])
 	{
@@ -38,8 +38,8 @@ class JobsResource extends ApiResource
 	/**
    	 * Patch a collection of jobs
    	 *
-   	 * @param Illuminate\Support\Collection $jobs
-   	 * @return Illuminate\Support\Collection
+   	 * @param EthicalJobs\SDK\Collection $jobs
+   	 * @return EthicalJobs\SDK\Collection
 	 */		
 	public function patchCollection(Collection $jobs)
 	{
@@ -49,8 +49,8 @@ class JobsResource extends ApiResource
 	/**
    	 * Put a collection of jobs
    	 *
-   	 * @param Illuminate\Support\Collection $jobs
-   	 * @return Illuminate\Support\Collection
+   	 * @param EthicalJobs\SDK\Collection $jobs
+   	 * @return EthicalJobs\SDK\Collection
 	 */		
 	public function putCollection(Collection $jobs)
 	{
@@ -60,8 +60,8 @@ class JobsResource extends ApiResource
 	/**
    	 * Chunk and make requests on a collection resource
    	 *
-   	 * @param Illuminate\Support\Collection $jobs
-   	 * @return Illuminate\Support\Collection
+   	 * @param EthicalJobs\SDK\Collection $jobs
+   	 * @return EthicalJobs\SDK\Collection
 	 */		
 	protected function collection($verb, Collection $jobs)
 	{

--- a/src/ResponseSelector.php
+++ b/src/ResponseSelector.php
@@ -2,8 +2,6 @@
 
 namespace EthicalJobs\SDK;
 
-use Illuminate\Support\Collection;
-
 /**
  * Response selector
  *
@@ -15,9 +13,9 @@ class ResponseSelector
 	/**
 	 * Response array
 	 *
-	 * @var Illuminate\Support\Collection
+	 * @var EthicalJobs\SDK\Collection
 	 */
-	protected $response = [];
+	protected $response;
 
 	/**
 	 * Object constructor
@@ -25,7 +23,7 @@ class ResponseSelector
 	 * @param iterable $response
 	 * @return void
 	 */
-	private function __construct(iterable $response)
+	public function __construct(iterable $response)
 	{
 		$this->setResponse($response);
 	}	
@@ -50,7 +48,7 @@ class ResponseSelector
 	public function setResponse(iterable $response): ResponseSelector
 	{
 		if (! $response instanceof Collection) {
-			$response = collect($response);
+			$response = new Collection($response);
 		}
 
 		$this->response = $response;
@@ -61,11 +59,11 @@ class ResponseSelector
 	/**
 	 * Gets the current response
 	 *
-	 * @return Illuminate\Support\Collection
+	 * @return EthicalJobs\SDK\Collection
 	 */
 	public function getResponse(): Collection
 	{
-		return $this->response;
+		return $this->response ?? new Collection;
 	}	
 
 	/**

--- a/tests/EndToEnd/ApiClientFetchTest.php
+++ b/tests/EndToEnd/ApiClientFetchTest.php
@@ -6,11 +6,11 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Contracts\Cache\Repository;
 use EthicalJobs\SDK\Authentication\TokenAuthenticator;
 use EthicalJobs\Tests\SDK\Fixtures;
+use EthicalJobs\SDK\Collection;
 use EthicalJobs\SDK\HttpClient;
 use EthicalJobs\SDK\ApiClient;
 

--- a/tests/Fixtures/Requests.php
+++ b/tests/Fixtures/Requests.php
@@ -2,7 +2,7 @@
 
 namespace EthicalJobs\Tests\SDK\Fixtures;
 
-use Illuminate\Support\Collection;
+use EthicalJobs\SDK\Collection;
 
 class Requests
 {
@@ -10,7 +10,7 @@ class Requests
 	 * Authentication response
 	 *
 	 * @param Integer $numberOfJobs
-	 * @return Illuminate\Support\Collection
+	 * @return EthicalJobs\SDK\Collection
 	 */
 	public static function jobsCollection($numberOfJobs)
 	{

--- a/tests/Integration/ApiClientTest.php
+++ b/tests/Integration/ApiClientTest.php
@@ -4,9 +4,9 @@ namespace EthicalJobs\Tests\SDK;
 
 use Mockery;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
+use EthicalJobs\SDK\Collection;
 use EthicalJobs\SDK\HttpClient;
 use EthicalJobs\SDK\Resources;
 use EthicalJobs\SDK\ApiClient;

--- a/tests/Integration/HttpClient/HttpResponseTest.php
+++ b/tests/Integration/HttpClient/HttpResponseTest.php
@@ -5,7 +5,7 @@ namespace EthicalJobs\Tests\Integration\SDK\HttpClient;
 use Mockery;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Collection;
+use EthicalJobs\SDK\Collection;
 use EthicalJobs\Tests\SDK\TestCase;
 use EthicalJobs\SDK\HttpClient;
 

--- a/tests/Integration/HttpClient/HttpVerbTest.php
+++ b/tests/Integration/HttpClient/HttpVerbTest.php
@@ -6,7 +6,7 @@ use Mockery;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Collection;
+use EthicalJobs\SDK\Collection;
 use EthicalJobs\Tests\SDK\TestCase;
 use EthicalJobs\SDK\HttpClient;
 

--- a/tests/Integration/Repositories/ResourceRepositoryTest.php
+++ b/tests/Integration/Repositories/ResourceRepositoryTest.php
@@ -2,10 +2,10 @@
 
 namespace EthicalJobs\Tests\SDK\Repositories;
 
-use Illuminate\Support\Collection;
 use EthicalJobs\SDK\Repositories\ResourceRepository;
 use EthicalJobs\Tests\SDK\TestCase;
 use EthicalJobs\SDK\Resources;
+use EthicalJobs\SDK\Collection;
 
 class ResourceRepositoryTest extends TestCase
 {

--- a/tests/Integration/Resources/Jobs/ApprovedJobsTest.php
+++ b/tests/Integration/Resources/Jobs/ApprovedJobsTest.php
@@ -3,10 +3,10 @@
 namespace EthicalJobs\Tests\SDK\Resources\Jobs;
 
 use Mockery;
-use Illuminate\Support\Collection;
 use EthicalJobs\SDK\Resources\JobsResource;
 use EthicalJobs\Tests\SDK\TestCase;
 use EthicalJobs\SDK\Enumerables;
+use EthicalJobs\SDK\Collection;
 use EthicalJobs\SDK\HttpClient;
 
 class ApprovedJobsTest extends TestCase

--- a/tests/Integration/Resources/Jobs/JobsCollectionsTest.php
+++ b/tests/Integration/Resources/Jobs/JobsCollectionsTest.php
@@ -3,11 +3,11 @@
 namespace EthicalJobs\Tests\SDK\Resources\Jobs;
 
 use Mockery;
-use Illuminate\Support\Collection;
 use EthicalJobs\Tests\SDK\Fixtures;
 use EthicalJobs\SDK\Resources\JobsResource;
 use EthicalJobs\Tests\SDK\TestCase;
 use EthicalJobs\SDK\HttpClient;
+use EthicalJobs\SDK\Collection;
 
 
 class JobsCollectionsTest extends TestCase

--- a/tests/Unit/Collection/CollectionTest.php
+++ b/tests/Unit/Collection/CollectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace EthicalJobs\Tests\SDK\Unit\Collection;
+
+use EthicalJobs\SDK\Collection;
+use EthicalJobs\SDK\ResponseSelector;
+
+class CollectionTest extends \EthicalJobs\Tests\SDK\TestCase
+{
+    /**
+     * @test
+     * @group Unit
+     */
+    public function its_select_function_returns_a_response_selector()
+    {
+        $collection = new Collection([ 'data' => [ 'foo' => 'bar'] ]);
+
+        $this->assertInstanceOf(ResponseSelector::class, $collection->select());
+    }    
+
+    /**
+     * @test
+     * @group Unit
+     */
+    public function its_select_function_can_select_data()
+    {
+        $response = new Collection([
+            'data' => [
+                'entities'  => [
+                    'jobs'  => [
+                        827 => ['id' => 827, 'title' => 'Developer'],
+                        276 => ['id' => 276, 'title' => 'Engineer'],
+                        98 => ['id' => 98, 'title' => 'Web Designer'],
+                    ],
+                    'users' => [
+                        111 => ['id' => 111, 'name' => 'John'],
+                        276 => ['id' => 276, 'name' => 'Andrew'],
+                        182 => ['id' => 182, 'name' => 'Jan'],
+                    ],
+                ],
+                'result' => 276,
+            ],
+        ]);
+
+        $user = $response->select()->byId('users', 276);
+
+        $this->assertEquals($user, ['id' => 276, 'name' => 'Andrew']);
+    }       
+}

--- a/tests/Unit/ResponseSelector/ResponseSelectorByIdTest.php
+++ b/tests/Unit/ResponseSelector/ResponseSelectorByIdTest.php
@@ -3,6 +3,7 @@
 namespace EthicalJobs\Tests\SDK;
 
 use EthicalJobs\SDK\ResponseSelector;
+use EthicalJobs\SDK\Collection;
 
 class ResponseSelectorByIdTest extends TestCase
 {
@@ -12,7 +13,7 @@ class ResponseSelectorByIdTest extends TestCase
      */
     public function it_can_select_an_entity_by_Id()
     {
-        $response = collect([
+        $response = new Collection([
             'data' => [
                 'entities'  => [
                     'jobs'  => [
@@ -39,7 +40,7 @@ class ResponseSelectorByIdTest extends TestCase
      */
     public function it_returns_empty_array_when_params_are_invalid()
     {
-        $response = collect([
+        $response = new Collection([
             'data' => [
                 'entities'  => [
                     'jobs'  => [

--- a/tests/Unit/ResponseSelector/ResponseSelectorByResultTest.php
+++ b/tests/Unit/ResponseSelector/ResponseSelectorByResultTest.php
@@ -3,6 +3,7 @@
 namespace EthicalJobs\Tests\SDK;
 
 use EthicalJobs\SDK\ResponseSelector;
+use EthicalJobs\SDK\Collection;
 
 class ResponseSelectorByResultTest extends TestCase
 {
@@ -12,7 +13,7 @@ class ResponseSelectorByResultTest extends TestCase
      */
     public function it_can_select_an_entity_by_result()
     {
-        $response = collect([
+        $response = new Collection([
             'data' => [
                 'entities'  => [
                     'jobs'  => [
@@ -39,7 +40,7 @@ class ResponseSelectorByResultTest extends TestCase
      */
     public function it_returns_empty_array_when_params_are_invalid()
     {
-        $response = collect([
+        $response = new Collection([
             'data' => [
                 'entities'  => [
                     'jobs'  => [

--- a/tests/Unit/ResponseSelector/ResponseSelectorEntitiesTest.php
+++ b/tests/Unit/ResponseSelector/ResponseSelectorEntitiesTest.php
@@ -3,6 +3,7 @@
 namespace EthicalJobs\Tests\SDK;
 
 use EthicalJobs\SDK\ResponseSelector;
+use EthicalJobs\SDK\Collection;
 
 class ResponseSelectorEntitiesTest extends TestCase
 {
@@ -12,7 +13,7 @@ class ResponseSelectorEntitiesTest extends TestCase
      */
     public function it_can_select_an_entities_array()
     {
-        $response = collect([
+        $response = new Collection([
             'data' => [
                 'entities'  => [
                     'jobs'  => [
@@ -43,7 +44,7 @@ class ResponseSelectorEntitiesTest extends TestCase
      */
     public function it_returns_empty_array_when_params_are_invalid()
     {
-        $response = collect([
+        $response = new Collection([
             'data' => [
                 'entities'  => [
                     'jobs'  => [

--- a/tests/Unit/ResponseSelector/ResponseSelectorTest.php
+++ b/tests/Unit/ResponseSelector/ResponseSelectorTest.php
@@ -3,6 +3,7 @@
 namespace EthicalJobs\Tests\SDK;
 
 use EthicalJobs\SDK\ResponseSelector;
+use EthicalJobs\SDK\Collection;
 
 class ResponseSelectorTest extends TestCase
 {
@@ -12,9 +13,9 @@ class ResponseSelectorTest extends TestCase
      */
     public function it_can_set_and_get_ites_response()
     {
-        $responseOne = collect([ 'data' => [ 'foo' => 'bar'] ]);
+        $responseOne = new Collection([ 'data' => [ 'foo' => 'bar'] ]);
 
-        $responseTwo = collect([ 'datum' => [ 'foo' => 'bar-bar-bar'] ]);
+        $responseTwo = new Collection([ 'datum' => [ 'foo' => 'bar-bar-bar'] ]);
 
         $selector = ResponseSelector::select($responseOne);
 
@@ -37,6 +38,6 @@ class ResponseSelectorTest extends TestCase
 
         $this->assertTrue(is_iterable($selector->getResponse()));
 
-        $this->assertEquals($selector->getResponse(), collect($response));
+        $this->assertEquals($selector->getResponse(), new Collection($response));
     }        
 }


### PR DESCRIPTION
Creating an extended `Illuminate\Support\Collection` class so we can have some easy to use sugar when "selecting" items from an API response.

### This

```php
$response = EthicalJobs::get('/jobs', ['status' => 'APPROVED');

$job = ResponseSelector::select($response)->entityById('jobs', 37648);
```

### Becomes this

```php
$response = EthicalJobs::get('/jobs', ['status' => 'APPROVED');

$job = $response->select()->entityById('jobs', 37648);
```

of course the response also has all the usual `Collection` methods.